### PR TITLE
Support tag_values

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,11 @@ jobs:
         #
         tag_value: ${{ github.ref }}
 
+        # A comma-separated list of values to update within the Values file(s).
+        # The number of values should match the number of keys in tag_keys.
+        # The values appear in the same order as the keys.
+        # tag_values: ''
+
         # This is the sem-ver level that will be bumped for each release.
         # `major`, `minor`, `path` or `null` are allowed. If you set `null` then
         # it will skip bumping the version.

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,10 @@ inputs:
     description: The destination tag (the new tag) to create and publish
     required: true
 
+  tag_values:
+    description: Comma-separated values for tag_keys.
+    required: false
+
   bump_level:
     description: >-
       `patch`, `minor`, `major`, or `null` to skip bumping the Chart version.


### PR DESCRIPTION
Tested in the experimental repo:

(existing functionality) Single tag_value for multiple tag keys: https://github.com/Nextdoor/dx-mock-repo-one/actions/runs/2394120436
The dangling commit: https://github.com/Nextdoor/dx-mock-repo-one/commit/b1f116d8132b9827bc5a02e5397fe8f65b6b868f

Multiple tag_values: https://github.com/Nextdoor/dx-mock-repo-one/runs/6619268484?check_suite_focus=true
The dangling commit: https://github.com/Nextdoor/dx-mock-repo-one/commit/ebb436803f2fdd8220c68dc69e1f438a2803a740