### PR TITLE
Return success if condition fails

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -96,6 +96,7 @@ _git_tag() {
 _git_push() {
   [ -n "${INPUT_COMMIT_BRANCH}" ] && git push origin "${INPUT_COMMIT_BRANCH}" "${FORCE_OPT}"
   [ -n "${INPUT_COMMIT_TAG}" ] && git push origin "${INPUT_COMMIT_TAG}" "${FORCE_OPT}"
+  return 0
 }
 
 


### PR DESCRIPTION
Bash functions return the status code of the last command. This was causing `_git_push` to return 1 even in 'success' cases such as both `INPUT_COMMIT_BRANCH` and `INPUT_COMMIT_TAG` being empty strings. This in turn causes workflow jobs to fail as `_git_push` returning non-zero causes the script to return non-zero.

The proposed change has `_git_push` return 0 if the end of the function is reached.