### PR TITLE
fix: Return successfully when no commit_tag

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -108,6 +108,7 @@ _git_tag() {
 _git_push() {
   [ -n "${INPUT_COMMIT_BRANCH}" ] && git push origin "${INPUT_COMMIT_BRANCH}" "${FORCE_OPT}"
   [ -n "${INPUT_COMMIT_TAG}" ] && git push origin "${INPUT_COMMIT_TAG}" "${FORCE_OPT}"
+  return 0
 }
 
 


### PR DESCRIPTION
Similarly to https://github.com/Nextdoor/helm-set-image-tag-action/pull/4 we get a non-zero status code returned by this action when providing a value for `INPUT_COMMIT_BRANCH` but not `INPUT_COMMIT_TAG`. This is due to `_git_push()` returning exit code 1.